### PR TITLE
Adds single end cutadapt rule

### DIFF
--- a/snakemake_rules/bio/ngs/qc/_cutadapt/cutadapt_cut_single_end.rule
+++ b/snakemake_rules/bio/ngs/qc/_cutadapt/cutadapt_cut_single_end.rule
@@ -1,0 +1,24 @@
+# -*- snakemake -*-
+config_default = {
+    'bio.ngs.qc.cutadapt' : {
+        'single_end' : {
+            'options' : "",
+        },
+    },
+}
+
+update_config(config_default, config)
+config = config_default
+
+
+rule cutadapt_cut_single_end:
+    """Cutadapt: cut single end sequences"""
+    params: cmd = config['bio.ngs.qc.cutadapt']['cmd'],
+            options = config['bio.ngs.qc.cutadapt']['single_end']['options'],
+            threeprime = config['bio.ngs.qc.cutadapt']['threeprime'],
+            fiveprime = config['bio.ngs.qc.cutadapt']['fiveprime']
+    input: read = "{prefix}" + config['bio.ngs.settings']['fastq_suffix'],
+    output: read = "{prefix}" + ".trimmed" + config['bio.ngs.settings']['fastq_suffix'],
+            log = "{prefix}.cutadapt_metrics"
+    log: "{prefix}.cutadapt_metrics"
+    shell: "{params.cmd} {params.options} {input.read} -b {params.fiveprime} -b {params.threeprime} -o {output.read} > {log}"


### PR DESCRIPTION
I am creating my own workflow using snakemaklib-core and there are some general rules that I would like to add to your rules upstream. Not sure what you would be interested in adding, but thought I would start with this simple addition to include a single end version of cutadapt.
